### PR TITLE
Add Chains as experimental feature

### DIFF
--- a/novaposhta/chains.py
+++ b/novaposhta/chains.py
@@ -1,0 +1,104 @@
+"""Chain of calls with error handling and data passing between calls. """
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
+
+T = TypeVar("T")
+
+
+@dataclass
+class ChainResult:
+    """
+    Result of a single chain execution.
+    """
+
+    success: bool
+    data: Optional[Any]
+    error: Optional[str]
+    next_kwargs: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class Chain:
+    """
+    Chain object that represents a single call in the chain.
+    """
+
+    method: Callable
+    kwargs: Optional[Dict[str, Any]] = None
+    prepare_next: Optional[Callable[[Any], Dict[str, Any]]] = None
+
+    async def execute(self, prev_result: Optional[ChainResult] = None) -> ChainResult:
+        """
+        Execute the chain.
+
+        :param prev_result: result of the previous chain.
+        :return: result of the current chain.
+        """
+        try:
+            execution_kwargs = {**(self.kwargs or {})}
+            if prev_result and prev_result.next_kwargs:
+                execution_kwargs.update(prev_result.next_kwargs)
+
+            result = self.method(**execution_kwargs)
+            if asyncio.iscoroutine(result):
+                result = await result
+
+            next_kwargs = self.prepare_next(result) if self.prepare_next else {}
+
+            return ChainResult(
+                success=result.get("success", False),
+                data=result.get("data"),
+                error=None,
+                next_kwargs=next_kwargs,
+            )
+        except Exception as e:
+            return ChainResult(success=False, data=None, error=str(e), next_kwargs=None)
+
+    def __or__(self, other: "Chain") -> "ChainExecutor":
+        """
+        Create a chain executor with the current chain and another chain.
+        Allows chaining multiple chains together via the `|` operator.
+
+        :param other: another chain.
+        :return ChainExecutor: chain executor with the current chain and another chain.
+        """
+        return ChainExecutor([self, other])
+
+
+class ChainExecutor:
+    """
+    Chain executor that executes multiple chains in a sequence.
+    """
+
+    def __init__(self, chains: Optional[List[Chain]] = None):
+        self.chains = chains or []
+
+    def __or__(self, chain: Chain) -> "ChainExecutor":
+        """
+        Add a chain to the chain executor.
+
+        :param chain: chain to add.
+        :return ChainExecutor: chain executor with the added chain.
+        """
+        self.chains.append(chain)
+        return self
+
+    async def execute_async(self) -> List[ChainResult]:
+        """
+        Execute all chains in the chain executor asynchronously.
+
+        :return: list of results of each chain execution
+        """
+        results = []
+        prev_result = None
+
+        for chain in self.chains:
+            result = await chain.execute(prev_result)
+            results.append(result)
+            if not result.success:
+                break
+            prev_result = result
+
+        return results

--- a/novaposhta/client.py
+++ b/novaposhta/client.py
@@ -1,6 +1,6 @@
 """Client for Nova Poshta API. """
 
-from typing import Callable, Final, Optional, Type, TypeVar
+from typing import Final, Optional, Type, TypeVar
 
 import httpx
 

--- a/novaposhta/types.py
+++ b/novaposhta/types.py
@@ -7,6 +7,7 @@ class RequestData(TypedDict):
     """
     Request data for Nova Poshta API.
     """
+
     apiKey: str
     modelName: str
     calledMethod: str
@@ -17,6 +18,7 @@ class HttpRequest(TypedDict):
     """
     Request data for HTTP client.
     """
+
     url: str
     headers: Dict[str, str]
     json: RequestData

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -1,0 +1,151 @@
+import pytest
+from unittest.mock import AsyncMock, Mock
+from novaposhta.chains import Chain, ChainResult, ChainExecutor
+
+
+@pytest.fixture
+def mock_method():
+    return AsyncMock(return_value={"success": True, "data": [{"Ref": "test-ref"}]})
+
+
+@pytest.fixture
+def mock_prepare_next():
+    return Mock(return_value={"extracted_ref": "test-ref"})
+
+
+@pytest.mark.asyncio
+async def test_chain_single_execution(mock_method, mock_prepare_next):
+    chain = Chain(method=mock_method, kwargs={"test": "value"}, prepare_next=mock_prepare_next)
+    result = await chain.execute()
+
+    mock_method.assert_called_once_with(test="value")
+    mock_prepare_next.assert_called_once_with({"success": True, "data": [{"Ref": "test-ref"}]})
+    assert isinstance(result, ChainResult)
+    assert result.success
+    assert result.data == [{"Ref": "test-ref"}]
+    assert result.next_kwargs == {"extracted_ref": "test-ref"}
+
+
+@pytest.mark.asyncio
+async def test_chain_with_prev_result(mock_method):
+    prev_result = ChainResult(
+        success=True,
+        data={"some": "data"},
+        error=None,
+        next_kwargs={"prev_param": "value"}
+    )
+    chain = Chain(method=mock_method)
+    await chain.execute(prev_result)
+
+    mock_method.assert_called_once_with(prev_param="value")
+
+
+@pytest.mark.asyncio
+async def test_chain_executor(mock_method, mock_prepare_next):
+    chain1 = Chain(method=mock_method, prepare_next=mock_prepare_next)
+    chain2 = Chain(method=mock_method)
+
+    executor = chain1 | chain2
+    results = await executor.execute_async()
+
+    assert len(results) == 2
+    assert all(isinstance(r, ChainResult) for r in results)
+    assert mock_method.call_count == 2
+    assert mock_prepare_next.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_chain_kwargs_merge():
+    method = AsyncMock(return_value={"success": True, "data": "test"})
+    chain = Chain(
+        method=method,
+        kwargs={"base": "value"},
+    )
+    prev_result = ChainResult(
+        success=True,
+        data="prev_data",
+        error=None,
+        next_kwargs={"additional": "value"}
+    )
+    await chain.execute(prev_result)
+
+    method.assert_called_once_with(base="value", additional="value")
+
+
+@pytest.mark.asyncio
+async def test_search_chain(mock_address_api):
+    chain = (
+            Chain(
+                mock_address_api.search_settlements,
+                kwargs={'city_name': 'Київ'},
+                prepare_next=lambda x: {'settlement_ref': x['data'][0]['Ref']}
+            ) |
+            Chain(
+                mock_address_api.search_settlement_streets,
+                prepare_next=lambda x: {'street_ref': x['data'][0]['Ref']}
+            )
+    )
+
+    results = await chain.execute_async()
+    assert len(results) == 2
+    assert all(isinstance(r, ChainResult) for r in results)
+    assert results[0].next_kwargs == {'settlement_ref': 'settlement-ref'}
+    assert results[1].next_kwargs == {'street_ref': 'street-ref'}
+
+
+@pytest.mark.asyncio
+async def test_chain_preserves_original_data(mock_method, mock_prepare_next):
+    chain = Chain(method=mock_method, prepare_next=mock_prepare_next)
+    result = await chain.execute()
+
+    assert result.data == [{"Ref": "test-ref"}]  # Original
+    assert result.next_kwargs == {"extracted_ref": "test-ref"}  # Transformed
+
+
+@pytest.mark.asyncio
+async def test_chain_execution_error(mock_method, mock_prepare_next):
+    mock_method.side_effect = Exception("Test error")
+    chain = Chain(method=mock_method, prepare_next=mock_prepare_next)
+    result = await chain.execute()
+
+    assert not result.success
+    assert result.data is None
+    assert result.error == "Test error"
+    assert result.next_kwargs is None
+
+
+def test_chain_executor_combination(mock_method, mock_prepare_next):
+    chain = Chain(method=mock_method, prepare_next=mock_prepare_next)
+    executor = ChainExecutor([chain])
+    assert executor.chains == [chain]
+
+    chain2 = Chain(method=mock_method)
+    executor | chain2
+
+    assert executor.chains == [chain, chain2]
+
+
+@pytest.mark.asyncio
+async def test_chain_executor_stops_on_no_success(mock_method, mock_prepare_next):
+    chain = Chain(method=mock_method, prepare_next=mock_prepare_next)
+    failed_chain = Chain(method=mock_method, prepare_next=mock_prepare_next)
+    failed_chain.execute = AsyncMock(return_value=ChainResult(success=False, data=None, error=None, next_kwargs=None))
+    never_called_chain = Chain(method=mock_method, prepare_next=mock_prepare_next)
+    result = await ChainExecutor([chain, failed_chain, never_called_chain]).execute_async()
+    assert len(result) == 2
+
+
+@pytest.fixture
+def mock_address_api():
+    api = Mock()
+    api.search_settlements = AsyncMock(return_value={
+        "success": True,
+        "data": [{"Ref": "settlement-ref"}]
+    })
+    api.search_settlement_streets = AsyncMock(return_value={
+        "success": True,
+        "data": [{"Ref": "street-ref"}]
+    })
+    return api
+
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,7 +133,7 @@ async def test_async_client_context_manager(httpx_mock):
     httpx_mock.add_response(json=json_response, status_code=200)
 
     async with NovaPoshtaApi(
-        TEST_API_KEY, api_endpoint=TEST_URI, async_mode=True
+            TEST_API_KEY, api_endpoint=TEST_URI, async_mode=True
     ) as client:
         model = client.new(MockModel)
         saved_model = client.get(MockModel.name)
@@ -160,3 +160,20 @@ def test_client_init_validation():
         NovaPoshtaApi(TEST_API_KEY, api_endpoint=TEST_URI, timeout=0)
     with pytest.raises(ValueError):
         NovaPoshtaApi(TEST_API_KEY, api_endpoint=TEST_URI, timeout=0, async_mode=True)
+
+
+@pytest.mark.asyncio
+async def test_client_fails_on_async_call_with_sync_client(httpx_mock):
+    client = NovaPoshtaApi(TEST_API_KEY, api_endpoint=TEST_URI)
+    with pytest.raises(ValueError) as e:
+        req = {"url": TEST_URI, "json": {}}
+        await client._send_async(req)
+    assert "Async client is not initialized" in str(e.value)
+
+
+def test_client_fails_on_sync_call_with_async_client(httpx_mock):
+    client = NovaPoshtaApi(TEST_API_KEY, api_endpoint=TEST_URI, async_mode=True)
+    with pytest.raises(ValueError) as e:
+        req = {"url": TEST_URI, "json": {}}
+        client._send_sync(req)
+    assert "Sync client is not initialized" in str(e.value)


### PR DESCRIPTION
The chain functionality allows you to sequence multiple API operations, where each operation's output can be transformed and passed to the next operation. This is particularly useful for scenarios that require multiple dependent API calls, like searching for addresses or creating shipments.
Each result of `prepare_next` is passed to the next operation as updated `kwargs`.